### PR TITLE
Fix GitHub Security integration for Trivy and Bandit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       security-events: write
+      contents: read
     steps:
     - uses: actions/checkout@v5
     
@@ -73,7 +74,8 @@ jobs:
     
     - name: Security audit with Bandit
       run: |
-        bandit -r src/ -f json -o bandit-report.json || true
+        # Generate both SARIF for GitHub Security and human-readable output
+        bandit -r src/ -f sarif -o bandit-report.sarif || true
         bandit -r src/ -f txt
       continue-on-error: true
     
@@ -81,7 +83,7 @@ jobs:
       uses: github/codeql-action/upload-sarif@v3
       if: always()
       with:
-        sarif_file: bandit-report.json
+        sarif_file: bandit-report.sarif
       continue-on-error: true
     
     - name: Check dependencies with Safety
@@ -111,13 +113,16 @@ jobs:
       with:
         name: security-reports
         path: |
-          bandit-report.json
+          bandit-report.sarif
           safety-report.json
           pip-audit-report.json
 
   # Vulnerability Scanning
   vulnerability-scan:
     runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      contents: read
     steps:
     - uses: actions/checkout@v5
     

--- a/.gitignore
+++ b/.gitignore
@@ -79,6 +79,8 @@ temp/
 
 # Security scan reports
 bandit-report*.json
+bandit-report*.sarif
+trivy-results.sarif
 
 # Docker
 .dockerignore


### PR DESCRIPTION
## Summary
Fixes the GitHub Security tab integration issues that were causing failures when uploading vulnerability scan results.

## Changes Made
- **Fixed Trivy permissions**: Added `security-events: write` permission to vulnerability-scan job
- **Fixed Bandit format**: Changed from JSON to SARIF format for GitHub Security tab compatibility  
- **Updated .gitignore**: Added SARIF security report files to prevent accidental commits
- **Improved permissions**: Ensured both security jobs have proper permissions (security-events + contents)

## Problem Solved
The error "Resource not accessible by integration" when uploading SARIF results to GitHub Security tab was caused by:
1. Missing `security-events: write` permission on the vulnerability-scan job
2. Bandit generating JSON instead of SARIF format (GitHub Security requires SARIF)

## Test Plan
- [x] GitHub Actions workflow runs without permission errors
- [x] Trivy results upload successfully to Security tab
- [x] Bandit results upload successfully to Security tab
- [x] Security scan reports are properly excluded from git

🤖 Generated with [Claude Code](https://claude.ai/code)